### PR TITLE
Use %H for 24-hour time

### DIFF
--- a/lib/ruby-pota-csv-to-adif.rb
+++ b/lib/ruby-pota-csv-to-adif.rb
@@ -47,7 +47,7 @@ module PotaCsvToAdif
 ADIF Export from ruby-pota-csv-to-adif v[0.3]
 https://github.com/ecopony/ruby-pota-csv-to-adif
 Copyright (C) 2021-2022 Edward Copony
-File generated on #{Time.now.getutc.strftime('%d %b, %Y at %I:%M')}
+File generated on #{Time.now.getutc.strftime('%d %b, %Y at %H:%M')}
 <ADIF_VER:5>3.1.0
 <PROGRAMID:21>ruby-pota-csv-to-adif
 <PROGRAMVERSION:3>0.3


### PR DESCRIPTION
`%I` is used for 12-hour time, but `%p` wasn't in the format string, so running the program in the afternoon (UTC) gave surprising results.  24-hour time is probably clearer in this context.